### PR TITLE
Fix vertex color transfer problem

### DIFF
--- a/zenoblend/main.cpp
+++ b/zenoblend/main.cpp
@@ -338,20 +338,21 @@ PYBIND11_MODULE(pylib_zenoblend, m) {
         auto const &attr = mesh->loop.attrs.at(attrName);
         auto attrIndex = attr.index();
         auto loopColor = reinterpret_cast<MLoopCol *>(loopColorPtr);
+        const double gamma = 1.0 / 2.2;
         if (attrIndex == 0) {
             #pragma omp parallel for
             for (int i = 0; i < loopCount; i++) {
                 auto color = std::get<0>(attr)[i];
-                loopColor[i].r = static_cast<unsigned char>(zeno::clamp(color[0] * 255, 0, 255));
-                loopColor[i].g = static_cast<unsigned char>(zeno::clamp(color[1] * 255, 0, 255));
-                loopColor[i].b = static_cast<unsigned char>(zeno::clamp(color[2] * 255, 0, 255));
+                loopColor[i].r = static_cast<unsigned char>(zeno::clamp(pow(color[0], gamma) * 255.0, 0.0, 255.0));
+                loopColor[i].g = static_cast<unsigned char>(zeno::clamp(pow(color[1], gamma) * 255.0, 0.0, 255.0));
+                loopColor[i].b = static_cast<unsigned char>(zeno::clamp(pow(color[2], gamma) * 255.0, 0.0, 255.0));
                 loopColor[i].a = 255; // todo: support vec4f attributes in future
             }
         } else if (attrIndex == 1) {
             #pragma omp parallel for
             for (int i = 0; i < loopCount; i++) {
                 auto color = std::get<1>(attr)[i];
-                auto graylevel = static_cast<unsigned char>(zeno::clamp(color * 255, 0, 255));
+                auto graylevel = static_cast<unsigned char>(zeno::clamp(pow(color, gamma) * 255.0, 0.0, 255.0));
                 loopColor[i].r = graylevel;
                 loopColor[i].g = graylevel;
                 loopColor[i].b = graylevel;

--- a/zenoblend/scenario.py
+++ b/zenoblend/scenario.py
@@ -101,9 +101,10 @@ def meshToBlender(meshPtr, mesh):
     core.meshGetLoops(meshPtr, loopPtr, loopCount)
 
     for attrName, attrType in core.meshGetLoopAttrNameType(meshPtr).items():
-        if attrName not in mesh.vertex_colors:
-            mesh.vertex_colors.active = mesh.vertex_colors.new(name=attrName)
-        loopColorPtr = mesh.vertex_colors[attrName].data[0].as_pointer() if loopCount else 0
+        bl_attr_name = 'Zeno_'+attrName
+        if bl_attr_name not in mesh.vertex_colors:
+            mesh.vertex_colors.active = mesh.vertex_colors.new(name=bl_attr_name)
+        loopColorPtr = mesh.vertex_colors[bl_attr_name].data[0].as_pointer() if loopCount else 0
         core.meshGetLoopColor(meshPtr, attrName, loopColorPtr, loopCount)
 
     polyCount = core.meshGetPolygonsCount(meshPtr)

--- a/zenoblend/scenario.py
+++ b/zenoblend/scenario.py
@@ -103,7 +103,7 @@ def meshToBlender(meshPtr, mesh):
     for attrName, attrType in core.meshGetLoopAttrNameType(meshPtr).items():
         bl_attr_name = 'Zeno_'+attrName
         if bl_attr_name not in mesh.vertex_colors:
-            mesh.vertex_colors.active = mesh.vertex_colors.new(name=bl_attr_name)
+            mesh.vertex_colors.new(name=bl_attr_name)
         loopColorPtr = mesh.vertex_colors[bl_attr_name].data[0].as_pointer() if loopCount else 0
         core.meshGetLoopColor(meshPtr, attrName, loopColorPtr, loopCount)
 


### PR DESCRIPTION
- Fix Gamma correction issues
![gamma correction](https://user-images.githubusercontent.com/10691820/132812469-5e5f6667-acdb-4085-9b65-5a8d4c874fc6.png)
- Fix blender attribute naming conflict issues (just a hack for now)

I believe it would be better if we can specify which zeno point attributes will be converted into blender vertex colors. It could be handy to have a UI to type attribute names like the following Sverchok node. However, I doubt whether we can make this kind of UI compatible with the current Zeno graph execution system or not.

![UI](https://user-images.githubusercontent.com/10691820/132813066-70a24c13-e657-4116-b5db-d700f5986a0b.png)




 